### PR TITLE
Hotfix - Persist update

### DIFF
--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -308,7 +308,7 @@ class UnitOfWork
         $id = $this->entityIds[$oid];
         $entity = $this->entitiesById[$id];
         
-        // Clone entity if it was not cloned before - else update persist issues will show up
+        // Clone entity if it was not cloned before - else update persist issues will show up.
         if(!isset($this->entityStateReferences[$id])) {
             $this->entityStateReferences[$id] = clone $entity;
         }


### PR DESCRIPTION
Updated entities were cloned too much - there was no check if they have been cloned before so update changes on an entity didnt work 